### PR TITLE
Bug/build

### DIFF
--- a/src/Acceleratio.SPDG.UI/Acceleratio.SPDG.UI.csproj
+++ b/src/Acceleratio.SPDG.UI/Acceleratio.SPDG.UI.csproj
@@ -14,20 +14,7 @@
     <TargetFrameworkProfile />
     <IsWebBootstrapper>false</IsWebBootstrapper>
     <PublishUrl>publish\</PublishUrl>
-    <Install>true</Install>
-    <InstallFrom>Disk</InstallFrom>
-    <UpdateEnabled>false</UpdateEnabled>
-    <UpdateMode>Foreground</UpdateMode>
-    <UpdateInterval>7</UpdateInterval>
-    <UpdateIntervalUnits>Days</UpdateIntervalUnits>
-    <UpdatePeriodically>false</UpdatePeriodically>
-    <UpdateRequired>false</UpdateRequired>
-    <MapFileExtensions>true</MapFileExtensions>
     <PublisherName>SysKit Ltd.</PublisherName>
-    <ApplicationRevision>0</ApplicationRevision>
-    <ApplicationVersion>1.0.0.%2a</ApplicationVersion>
-    <UseApplicationTrust>false</UseApplicationTrust>
-    <BootstrapperEnabled>true</BootstrapperEnabled>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <PlatformTarget>AnyCPU</PlatformTarget>

--- a/src/Acceleratio.SPDG.UI/Acceleratio.SPDG.UI.csproj
+++ b/src/Acceleratio.SPDG.UI/Acceleratio.SPDG.UI.csproj
@@ -65,7 +65,7 @@
     <WebPage>publish.htm</WebPage>
     <ApplicationRevision>4</ApplicationRevision>
     <ApplicationVersion>1.5.0.%2a</ApplicationVersion>
-    <ApplicationVersion Condition="'$(build_number)' != ''">0.5.1.$(build_number)</ApplicationVersion>
+    <ApplicationVersion Condition="'$(build_number)' != ''">1.5.1.$(build_number)</ApplicationVersion>
     <UseApplicationTrust>false</UseApplicationTrust>
     <PublishWizardCompleted>true</PublishWizardCompleted>
     <BootstrapperEnabled>true</BootstrapperEnabled>

--- a/src/Acceleratio.SPDG.UI/Acceleratio.SPDG.UI.csproj
+++ b/src/Acceleratio.SPDG.UI/Acceleratio.SPDG.UI.csproj
@@ -14,7 +14,20 @@
     <TargetFrameworkProfile />
     <IsWebBootstrapper>false</IsWebBootstrapper>
     <PublishUrl>publish\</PublishUrl>
+    <Install>true</Install>
+    <InstallFrom>Disk</InstallFrom>
+    <UpdateEnabled>false</UpdateEnabled>
+    <UpdateMode>Foreground</UpdateMode>
+    <UpdateInterval>7</UpdateInterval>
+    <UpdateIntervalUnits>Days</UpdateIntervalUnits>
+    <UpdatePeriodically>false</UpdatePeriodically>
+    <UpdateRequired>false</UpdateRequired>
+    <MapFileExtensions>true</MapFileExtensions>
     <PublisherName>SysKit Ltd.</PublisherName>
+    <ApplicationRevision>0</ApplicationRevision>
+    <ApplicationVersion>1.0.0.%2a</ApplicationVersion>
+    <UseApplicationTrust>false</UseApplicationTrust>
+    <BootstrapperEnabled>true</BootstrapperEnabled>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <PlatformTarget>AnyCPU</PlatformTarget>
@@ -71,10 +84,7 @@
   </PropertyGroup>
   <PropertyGroup>
     <ManifestCertificateThumbprint>EC446C2D7D3542DB583492857652D500CBF5406C</ManifestCertificateThumbprint>
-  </PropertyGroup>
-  <PropertyGroup>
-    <ManifestKeyFile>Acceleratio.SPDG.UI_TemporaryKey.pfx</ManifestKeyFile>
-  </PropertyGroup>
+  </PropertyGroup>  
   <PropertyGroup>
     <SignManifests>false</SignManifests>
   </PropertyGroup>
@@ -83,7 +93,7 @@
     <SignAssembly>true</SignAssembly>
     <SignManifests>true</SignManifests>
     <AssemblyOriginatorKeyFile>C:\BuildTools\Acceleratio.snk</AssemblyOriginatorKeyFile>
-	<ManifestCertificateThumbprint>89D2738F1CE9C29EE41CBD929339563F0F23616B</ManifestCertificateThumbprint>
+    <ManifestCertificateThumbprint>3514BDAE43722F6C21914C79ADD31661727A13F9</ManifestCertificateThumbprint>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="System" />
@@ -256,7 +266,6 @@
     <EmbeddedResource Include="ucSteps.resx">
       <DependentUpon>ucSteps.cs</DependentUpon>
     </EmbeddedResource>
-    <None Include="Acceleratio.SPDG.UI_TemporaryKey.pfx" />
     <None Include="app.config" />
     <None Include="Properties\Settings.settings">
       <Generator>SettingsSingleFileGenerator</Generator>

--- a/src/Acceleratio.SPDG.UI/Acceleratio.SPDG.UI.csproj
+++ b/src/Acceleratio.SPDG.UI/Acceleratio.SPDG.UI.csproj
@@ -83,7 +83,6 @@
     <SignAssembly>true</SignAssembly>
     <SignManifests>true</SignManifests>
     <AssemblyOriginatorKeyFile>C:\BuildTools\Acceleratio.snk</AssemblyOriginatorKeyFile>
-    <ManifestCertificateThumbprint>89D2738F1CE9C29EE41CBD929339563F0F23616B</ManifestCertificateThumbprint>
     <ManifestKeyFile>C:\BuildTools\Acceleratio.pfx</ManifestKeyFile>
   </PropertyGroup>
   <ItemGroup>

--- a/src/Acceleratio.SPDG.UI/Acceleratio.SPDG.UI.csproj
+++ b/src/Acceleratio.SPDG.UI/Acceleratio.SPDG.UI.csproj
@@ -84,7 +84,6 @@
     <SignManifests>true</SignManifests>
     <AssemblyOriginatorKeyFile>C:\BuildTools\Acceleratio.snk</AssemblyOriginatorKeyFile>
 	<ManifestCertificateThumbprint>89D2738F1CE9C29EE41CBD929339563F0F23616B</ManifestCertificateThumbprint>
-    <ManifestKeyFile>C:\BuildTools\Acceleratio.pfx</ManifestKeyFile>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="System" />

--- a/src/Acceleratio.SPDG.UI/Acceleratio.SPDG.UI.csproj
+++ b/src/Acceleratio.SPDG.UI/Acceleratio.SPDG.UI.csproj
@@ -71,15 +71,15 @@
   </PropertyGroup>
   <PropertyGroup>
     <ManifestCertificateThumbprint>EC446C2D7D3542DB583492857652D500CBF5406C</ManifestCertificateThumbprint>
-  </PropertyGroup>  
+  </PropertyGroup>
   <PropertyGroup>
     <SignManifests>false</SignManifests>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)' == 'Release' AND Exists('C:\BuildTools\')">
     <PublishUrl>..\..\releases\ClickOnce</PublishUrl>
-	<ManifestCertificateThumbprint>3514BDAE43722F6C21914C79ADD31661727A13F9</ManifestCertificateThumbprint>
-	<ManifestKeyFile>C:\BuildTools\Acceleratio.pfx</ManifestKeyFile>
-	<SignAssembly>true</SignAssembly>
+    <ManifestCertificateThumbprint>3514BDAE43722F6C21914C79ADD31661727A13F9</ManifestCertificateThumbprint>
+    <ManifestKeyFile>C:\BuildTools\Acceleratio.pfx</ManifestKeyFile>
+    <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>C:\BuildTools\Acceleratio.snk</AssemblyOriginatorKeyFile>
     <SignManifests>true</SignManifests>
   </PropertyGroup>

--- a/src/Acceleratio.SPDG.UI/Acceleratio.SPDG.UI.csproj
+++ b/src/Acceleratio.SPDG.UI/Acceleratio.SPDG.UI.csproj
@@ -90,9 +90,11 @@
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)' == 'Release' AND Exists('C:\BuildTools\')">
     <PublishUrl>..\..\releases\ClickOnce</PublishUrl>
-    <SignManifests>true</SignManifests>
-    <ManifestCertificateThumbprint>3514BDAE43722F6C21914C79ADD31661727A13F9</ManifestCertificateThumbprint>
+	<ManifestCertificateThumbprint>3514BDAE43722F6C21914C79ADD31661727A13F9</ManifestCertificateThumbprint>
 	<ManifestKeyFile>C:\BuildTools\Acceleratio.pfx</ManifestKeyFile>
+	<SignAssembly>true</SignAssembly>
+    <AssemblyOriginatorKeyFile>C:\BuildTools\Acceleratio.snk</AssemblyOriginatorKeyFile>
+    <SignManifests>true</SignManifests>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="System" />

--- a/src/Acceleratio.SPDG.UI/Acceleratio.SPDG.UI.csproj
+++ b/src/Acceleratio.SPDG.UI/Acceleratio.SPDG.UI.csproj
@@ -90,9 +90,7 @@
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)' == 'Release' AND Exists('C:\BuildTools\')">
     <PublishUrl>..\..\releases\ClickOnce</PublishUrl>
-    <SignAssembly>true</SignAssembly>
     <SignManifests>true</SignManifests>
-    <AssemblyOriginatorKeyFile>C:\BuildTools\Acceleratio.snk</AssemblyOriginatorKeyFile>
     <ManifestCertificateThumbprint>3514BDAE43722F6C21914C79ADD31661727A13F9</ManifestCertificateThumbprint>
 	<ManifestKeyFile>C:\BuildTools\Acceleratio.pfx</ManifestKeyFile>
   </PropertyGroup>

--- a/src/Acceleratio.SPDG.UI/Acceleratio.SPDG.UI.csproj
+++ b/src/Acceleratio.SPDG.UI/Acceleratio.SPDG.UI.csproj
@@ -83,6 +83,7 @@
     <SignAssembly>true</SignAssembly>
     <SignManifests>true</SignManifests>
     <AssemblyOriginatorKeyFile>C:\BuildTools\Acceleratio.snk</AssemblyOriginatorKeyFile>
+	<ManifestCertificateThumbprint>89D2738F1CE9C29EE41CBD929339563F0F23616B</ManifestCertificateThumbprint>
     <ManifestKeyFile>C:\BuildTools\Acceleratio.pfx</ManifestKeyFile>
   </PropertyGroup>
   <ItemGroup>

--- a/src/Acceleratio.SPDG.UI/Acceleratio.SPDG.UI.csproj
+++ b/src/Acceleratio.SPDG.UI/Acceleratio.SPDG.UI.csproj
@@ -94,6 +94,7 @@
     <SignManifests>true</SignManifests>
     <AssemblyOriginatorKeyFile>C:\BuildTools\Acceleratio.snk</AssemblyOriginatorKeyFile>
     <ManifestCertificateThumbprint>3514BDAE43722F6C21914C79ADD31661727A13F9</ManifestCertificateThumbprint>
+	<ManifestKeyFile>C:\BuildTools\Acceleratio.pfx</ManifestKeyFile>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="System" />


### PR DESCRIPTION
Since we changed the code signing certificate in the fall of 2017 the thumbprint no longer worked since the old certificate expired. 

We imported the new certificate on the build server and changed the required thumbprint here. 
